### PR TITLE
Allow passing payloads to rollout route

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Deploy your application from a CI/CD pipeline via `cURL` + JWT auth.
 
 ```
-$ curl -s -H "Authorization: bearer abc..." https://example.com/your/rollout/path
+$ curl -s -d '{"git-branch": "main"}' -H "Authorization: bearer abc..." https://example.com/your/rollout/path
 Rollout complete
 ```
 
@@ -13,7 +13,7 @@ Instead of managing SSH keys in your CI/CD for accounts that have privileged acc
 
 Requires creating a JWT from your CI provider, and sending that token to this service running in your deployment environment to trigger a deployment script.
 
-Also requires a `rollout.sh` script that can handle all the command needing ran to rollout your software.
+Also requires a `rollout.sh` script that can handle all the commands needing ran to rollout your software.
 
 ## Install
 
@@ -29,7 +29,7 @@ $ docker run \
 
 ## OIDC Provider examples
 
-This service requires two envionrment variables.
+This service requires two environment variables.
 
 - `JWKS_URI` - the URL of the OIDC Provider's [JSON Web Key (JWK) set document](https://www.rfc-editor.org/info/rfc7517). This is used to ensure the JWT was signed by the provider.
 - `JWT_AUD` - the audience set in the JWT token.
@@ -39,6 +39,28 @@ This service requires two envionrment variables.
 ```
 - `ROLLOUT_CMD` (default: `/bin/bash`) - the command to execute a rollout
 - `ROLLOUT_ARGS` (default: `/rollout.sh` ) - the args to pass to `ROLLOUT_CMD`
+
+## Dynamic environment variables for ROLLOUT_CMD
+
+There are a few environment variables you can make available to your rollout command.
+
+These environment variables can be passed to the cURL command when rolling out your changes.
+
+For example, if you want your rollout script to have the git branch that is being deployed you can pass that in the rollout like so:
+
+```
+$ curl -s -d '{"git-branch": "main"}' -H "Authorization: bearer abc..." https://example.com/your/rollout/path
+```
+
+These are the environment variables currently supported, keyed by their respective JSON key name:
+
+- `docker-image` **:** `DOCKER_IMAGE`
+-	`docker-tag` **:** `DOCKER_TAG`
+-	`git-repo` **:** `GIT_REPO`
+-	`git-branch` **:** `GIT_BRANCH`
+-	`rollout-arg1` **:** `ROLLOUT_ARG1`
+-	`rollout-arg2` **:** `ROLLOUT_ARG2`
+-	`rollout-arg3` **:** `ROLLOUT_ARG3`
 
 ### GitHub
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ $ docker run \
   rollout:latest
 ```
 
+You should then proxy that port with some service that can handle TLS for you.
+
 ## OIDC Provider examples
 
 This service requires two environment variables.
@@ -46,21 +48,28 @@ There are a few environment variables you can make available to your rollout com
 
 These environment variables can be passed to the cURL command when rolling out your changes.
 
-For example, if you want your rollout script to have the git branch that is being deployed you can pass that in the rollout like so:
+For example, if you want your rollout script to have the git repo and branch that is being deployed you can pass that in the rollout cURL call as seen below. Doing so will make an environment variable `$GIT_REPO` and `$GIT_BRANCH` available in your rollout script.
 
 ```
-$ curl -s -d '{"git-branch": "main"}' -H "Authorization: bearer abc..." https://example.com/your/rollout/path
+$ curl -s \
+  -H "Authorization: bearer abc..." \
+  -d '{"git-repo": "git@github.com:lehigh-university-libraries/rollout.git", "git-branch": "main"}' \
+  https://example.com/your/rollout/path
 ```
 
 These are the environment variables currently supported, keyed by their respective JSON key name:
 
-- `docker-image` **:** `DOCKER_IMAGE`
--	`docker-tag` **:** `DOCKER_TAG`
--	`git-repo` **:** `GIT_REPO`
--	`git-branch` **:** `GIT_BRANCH`
--	`rollout-arg1` **:** `ROLLOUT_ARG1`
--	`rollout-arg2` **:** `ROLLOUT_ARG2`
--	`rollout-arg3` **:** `ROLLOUT_ARG3`
+| JSON Key       | Env Var Name  | Example JSON to send                 |
+|----------------|---------------| -------------------------------------
+| `docker-image` | `DOCKER_IMAGE`| `{"docker-image": "foo/bar:latest"}` |
+| `docker-tag`   | `DOCKER_TAG`  | `{"docker-tag": "latest"}`           |
+| `git-repo`     | `GIT_REPO`    | `{"repo": "foo/bar:latest"}`         |
+| `git-branch`   | `GIT_BRANCH`  | `{"git-branch": "main"}`             |
+| `rollout-arg1` | `ROLLOUT_ARG1`| `{"rollout-arg1": "FOO"}`            |
+| `rollout-arg2` | `ROLLOUT_ARG2`| `{"rollout-arg2": "BAR"}`            |
+| `rollout-arg3` | `ROLLOUT_ARG3`| `{"rollout-arg3": "BAZ"}`            |
+
+If there is key/env var name that is generic enough that it warrants its own placeholder, it can be added by submitting an issue or a PR. Otherwise, use the general ARG variables.
 
 ### GitHub
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ These are the environment variables currently supported, keyed by their respecti
 |----------------|---------------| -------------------------------------
 | `docker-image` | `DOCKER_IMAGE`| `{"docker-image": "foo/bar:latest"}` |
 | `docker-tag`   | `DOCKER_TAG`  | `{"docker-tag": "latest"}`           |
-| `git-repo`     | `GIT_REPO`    | `{"repo": "foo/bar:latest"}`         |
+| `git-repo`     | `GIT_REPO`    | `{"git-repo": "foo/bar:latest"}`         |
 | `git-branch`   | `GIT_BRANCH`  | `{"git-branch": "main"}`             |
 | `rollout-arg1` | `ROLLOUT_ARG1`| `{"rollout-arg1": "FOO"}`            |
 | `rollout-arg2` | `ROLLOUT_ARG2`| `{"rollout-arg2": "BAR"}`            |

--- a/main.go
+++ b/main.go
@@ -151,7 +151,7 @@ func ParseToken(token *jwt.Token) (interface{}, error) {
 	jwksUri := os.Getenv("JWKS_URI")
 	jwksSet, err := jwk.Fetch(ctx, jwksUri)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to fetch JWK set from %s: %v", jwksUri, err)
+		return nil, fmt.Errorf("unable to fetch JWK set from %s: %v", jwksUri, err)
 	}
 	// Find the appropriate key in JWKS
 	key, ok := jwksSet.LookupKeyID(kid)

--- a/main_test.go
+++ b/main_test.go
@@ -405,11 +405,10 @@ func TestBadRolloutCmdArgs(t *testing.T) {
 	}
 
 	payloads := []string{
-		`{"rollout-arg1": "bad1;"}`,
-		`{"rollout-arg1": "bad2&"}`,
-		`{"rollout-arg1": "bad3|"}`,
-		`{"rollout-arg1": "bad4$"}`,
-		"{\"rollout-arg1\": \"any`thing\"}",
+		`{"rollout-arg1": "any;thing"}`,
+		`{"rollout-arg1": "any&thing"}`,
+		`{"rollout-arg1": "any|thing"}`,
+		`{"rollout-arg1": "any$thing"}`,
 		`{"rollout-arg1": "any\"thing"}`,
 		`{"rollout-arg1": "any\thing"}`,
 		`{"rollout-arg1": "any*thing"}`,
@@ -423,6 +422,7 @@ func TestBadRolloutCmdArgs(t *testing.T) {
 		`{"rollout-arg1": "any<thing"}`,
 		`{"rollout-arg1": "any>thing"}`,
 		`{"rollout-arg1": "anything!"}`,
+		"{\"rollout-arg1\": \"any`thing\"}",
 	}
 	for _, payload := range payloads {
 		tt := Test{

--- a/main_test.go
+++ b/main_test.go
@@ -404,46 +404,34 @@ func TestBadRolloutCmdArgs(t *testing.T) {
 		t.Fatalf("Unable to create a JWT with our test key: %v", err)
 	}
 
-	payloads := map[string]string{
-		"rollout-arg1": "bad1;",
-		"rollout-arg2": "bad2&",
-		"rollout-arg3": "bad3|",
-		"bad4":         "bad4$",
-		"bad5":         "any`thing",
-		"bad6":         `any"thing`,
-		"bad7":         "any\thing",
-		"bad8":         "any*thing",
-		"bad9":         "any?thing",
-		"bad10":        "any[thing",
-		"bad11":        "any]thing",
-		"bad12":        "any{thing",
-		"bad13":        "any}thing",
-		"bad14":        "any(thing",
-		"bad15":        "any)thing",
-		"bad16":        "any<thing",
-		"bad17":        "any>thing",
-		"bad18":        "anything!",
+	payloads := []string{
+		`{"rollout-arg1": "bad1;"}`,
+		`{"rollout-arg1": "bad2&"}`,
+		`{"rollout-arg1": "bad3|"}`,
+		`{"rollout-arg1": "bad4$"}`,
+		"{\"rollout-arg1\": \"any`thing\"}",
+		`{"rollout-arg1": "any\"thing"}`,
+		`{"rollout-arg1": "any\thing"}`,
+		`{"rollout-arg1": "any*thing"}`,
+		`{"rollout-arg1": "any?thing"}`,
+		`{"rollout-arg1": "any[thing"}`,
+		`{"rollout-arg1": "any]thing"}`,
+		`{"rollout-arg1": "any{thing"}`,
+		`{"rollout-arg1": "any}thing"}`,
+		`{"rollout-arg1": "any(thing"}`,
+		`{"rollout-arg1": "any)thing"}`,
+		`{"rollout-arg1": "any<thing"}`,
+		`{"rollout-arg1": "any>thing"}`,
+		`{"rollout-arg1": "anything!"}`,
 	}
-	for k, v := range payloads {
-		var e string
-		switch k {
-		case "rollout-arg1":
-			e = "ROLLOUT_ARG1"
-		case "rollout-arg2":
-			e = "ROLLOUT_ARG2"
-		case "rollout-arg3":
-			e = "ROLLOUT_ARG3"
-		default:
-			k = "rollout-arg1"
-			e = "ROLLOUT_ARG1"
-		}
+	for _, payload := range payloads {
 		tt := Test{
-			name:           fmt.Sprintf("%s custom arg doesn't pass to rollout.sh", k),
+			name:           "Bad custom arg doesn't pass to rollout.sh",
 			authHeader:     "Bearer " + jwtToken,
 			expectedStatus: http.StatusBadRequest,
-			cmdArgs:        fmt.Sprintf(`-c "touch /tmp/$%s"`, e),
+			cmdArgs:        `-c "touch /tmp/$ROLLOUT_ARG1"`,
 			method:         "POST",
-			payload:        fmt.Sprintf(`{"%s": "%s"}`, k, v),
+			payload:        payload,
 			expectedBody:   "Bad request\n",
 		}
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
```
curl -H "Authorization: bearer xyz..." -d '{"git-branch": "custom-args"}' https://example.com/
```

Would make

```
$GIT_BRANCH
```

Available in the rollout command

Resolves #4 