### PR TITLE
[minor] add retry on rollout restart

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,7 @@
 linters:
   enable:
     - gofmt
-
+issues:
+  exclude-dirs:
+    - ../../go
+    - ../../../../opt

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This service requires two environment variables.
 ```
 - `ROLLOUT_CMD` (default: `/bin/bash`) - the command to execute a rollout
 - `ROLLOUT_ARGS` (default: `/rollout.sh` ) - the args to pass to `ROLLOUT_CMD`
+- `ROLLOUT_LOCK_FILE` (optional) - a lock file that is set during rollouts. When the file is on disk additional rollouts can not happen, and if the file is present on startup initiates a rollout
 
 ## Dynamic environment variables for ROLLOUT_CMD
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/lestrrat-go/jwx v1.2.30
-	github.com/lestrrat-go/jwx/v2 v2.1.3
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -19,7 +19,6 @@ github.com/lestrrat-go/iter v1.0.2 h1:gMXo1q4c2pHmC3dn8LzRhJfP1ceCbgSiT9lUydIzlt
 github.com/lestrrat-go/iter v1.0.2/go.mod h1:Momfcq3AnRlRjI5b5O8/G5/BvpzrhoFTZcn06fEOPt4=
 github.com/lestrrat-go/jwx v1.2.30 h1:VKIFrmjYn0z2J51iLPadqoHIVLzvWNa1kCsTqNDHYPA=
 github.com/lestrrat-go/jwx v1.2.30/go.mod h1:vMxrwFhunGZ3qddmfmEm2+uced8MSI6QFWGTKygjSzQ=
-github.com/lestrrat-go/jwx/v2 v2.1.3/go.mod h1:q6uFgbgZfEmQrfJfrCo90QcQOcXFMfbI/fO0NqRtvZo=
 github.com/lestrrat-go/option v1.0.0/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
 github.com/lestrrat-go/option v1.0.1 h1:oAzP2fvZGQKWkvHa1/SAcFolBEca1oN+mQ7eooNBEYU=
 github.com/lestrrat-go/option v1.0.1/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=


### PR DESCRIPTION
If the deployment process causes this service to restart (i.e. a new docker image is pulled on disk and `docker compose up` is ran in rollout), it can leave the rollout in a bad state. We can mitigate this by retrying if a lock file exists on startup.